### PR TITLE
Required plugin in tailwind config needs to be called

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ yarn add -D tailwindcss-break
   },
 
   plugins: [
-    require('tailwindcss-break'), // no options to configure
+    require('tailwindcss-break')(), // no options to configure
   ],
 }
 ```


### PR DESCRIPTION
Problem: break utility classes were not present in the compiled css file.
Solution: in the tailwind.config.js, in the plugins array, the required plugin needs to be called as a function.

The same phenomenon is present in your other package, https://github.com/hacknug/tailwindcss-multi-column.

Great package by the way, keep up the great work!